### PR TITLE
add: Command line options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ futures = "*"
 tokio = { version = "0.2", features = ["fs"] }
 
 # argument parsing
-clap = "2.0"
+clap = "2.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ openssl = { version = "0.10", features = ["v110"] }
 # futures
 futures = "*"
 tokio = { version = "0.2", features = ["fs"] }
+
+# argument parsing
+clap = "2.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,14 @@ impl Options {
         }
 
         if let Some(log_level) = matches.value_of("default-log-level") {
-            options.log_level = log_level.to_owned();
+            match log_level {
+                "warn" | "trace" | "debug" | "error" | "info" => {
+                    options.log_level = log_level.to_owned()
+                }
+                _ => eprintln!(
+                    "Incorrect value for default-log-level, using default value instead"
+                ),
+            }
         }
 
         options

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-extern crate clap;
 use clap::{crate_authors, crate_description, crate_name, crate_version, App, Arg};
 
 pub struct Options {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,51 @@
+extern crate clap;
+use clap::{crate_authors, crate_description, crate_name, crate_version, App, Arg};
+
+pub struct Options {
+    pub config_dir: String,
+    pub log_level: String,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            config_dir: String::from("config"),
+            log_level: String::from("info"),
+        }
+    }
+}
+
+impl Options {
+    pub fn new() -> Self {
+        let mut options = Options::default();
+
+        let matches = App::new(crate_name!())
+            .version(crate_version!())
+            .author(crate_authors!())
+            .about(crate_description!())
+            .arg(
+                Arg::with_name("config-dir")
+                    .short("c")
+                    .long("config-dir")
+                    .takes_value(true)
+                    .help("Path to configuration file directory."),
+            )
+            .arg(
+                Arg::with_name("default-log-level")
+                    .long("default-log-level")
+                    .takes_value(true)
+                    .help("Set default log level."),
+            )
+            .get_matches();
+
+        if let Some(config_dir) = matches.value_of("config-dir") {
+            options.config_dir = config_dir.to_owned();
+        }
+
+        if let Some(log_level) = matches.value_of("default-log-level") {
+            options.log_level = log_level.to_owned();
+        }
+
+        options
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,9 @@ mod error_handler;
 /// Tests.
 mod tests;
 
+// Cli options
+mod cli;
+
 use actix_files::NamedFile;
 use actix_web::middleware::errhandlers::ErrorHandlers;
 use actix_web::{http, middleware, web, App, HttpRequest, HttpResponse, HttpServer};
@@ -79,10 +82,13 @@ async fn redirect(
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // setup logger
-    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
-    let app_state = app_state::load_app_state("config");
+    let cli_options = cli::Options::new();
+
+    // setup logger
+    env_logger::Builder::from_env(Env::default().default_filter_or(cli_options.log_level)).init();
+
+    let app_state = app_state::load_app_state(cli_options.config_dir.as_ref());
 
     // clone config before it is moved into the closure
     let server_conf = app_state.config.server.clone();


### PR DESCRIPTION
Added command line arguments from #8. Note that 'default-log-level' argument is not checked, so users can enter some garbage string. Maybe we can check if the entered string is one of "warn", "trace", "debug", "error" or "info". 